### PR TITLE
Prevent the title from changing in the ConcordanceParameterFrame

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/ConcordanceParameterFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/ConcordanceParameterFrame.java
@@ -382,7 +382,6 @@ public class ConcordanceParameterFrame extends JInternalFrame {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
 				useWebBrowser = openWithBrowser.isSelected();
-				setTitle("" + useWebBrowser);
 			}
 		});
 		middlePanel.add(openWithBrowser, BorderLayout.CENTER);


### PR DESCRIPTION
Title of the frame no longer changes according to the value of useWebBrowser parameter.