### PR TITLE
Add specialized Open options for specific file types in File Edition Menu

### DIFF
--- a/unitex/src/fr/umlv/unitex/config/Config.java
+++ b/unitex/src/fr/umlv/unitex/config/Config.java
@@ -54,7 +54,6 @@ import javax.swing.JPanel;
 import javax.swing.JDialog;
 import javax.swing.JProgressBar;
 import javax.swing.SwingWorker;
-import javax.swing.SwingUtilities;
 
 import fr.umlv.unitex.Unitex;
 import fr.umlv.unitex.files.FileUtil;
@@ -209,6 +208,18 @@ public class Config {
      * Dialog box used to open files to edit
      */
     private static JFileChooser fileEditionDialogBox;
+    /**
+     * Dialog box used to open dictionary files to edit
+     */
+    private static JFileChooser dicFileEditionDialogBox;
+    /**
+     * Dialog box used to open text files to edit
+     */
+    private static JFileChooser txtFileEditionDialogBox;
+    /**
+     * Dialog box used to open cascade configuration files to edit
+     */
+    private static JFileChooser cscFileEditionDialogBox;
     /**
      * Dialog box used to choose an output text file for Fst2Unambig
      */
@@ -450,6 +461,42 @@ public class Config {
         fileEditionDialogBox.setCurrentDirectory(Config.getCurrentCorpusDir());
         fileEditionDialogBox.setDialogTitle("Select file to edit");
         return fileEditionDialogBox;
+    }
+    
+    public static JFileChooser initializeJFileChooser(JFileChooser jFileChooser,
+    		String extension, String description, String subfolder)
+    {
+    	if (jFileChooser != null)
+            return jFileChooser;
+        jFileChooser = new JFileChooser();
+        PersonalFileFilter fileFilter=new PersonalFileFilter(extension,
+                description); 
+        jFileChooser.addChoosableFileFilter(fileFilter);
+        jFileChooser.setFileFilter(fileFilter);
+        jFileChooser.setDialogType(JFileChooser.OPEN_DIALOG);
+        jFileChooser.setCurrentDirectory(new File(Config
+                .getUserCurrentLanguageDir(), subfolder));
+        jFileChooser.setMultiSelectionEnabled(false);
+        jFileChooser.setDialogTitle("Select file to edit");
+        return jFileChooser;
+    }
+    
+    public static JFileChooser getFileEditionDialogBox(String extension) {
+    	JFileChooser chooser;
+    	if(extension == null)
+    		chooser = getFileEditionDialogBox();
+    	else if(extension.equals("txt"))
+    		chooser = initializeJFileChooser(txtFileEditionDialogBox,"txt",
+    				"Text Files", "Corpus");
+    	else if(extension.equals("dic"))
+			chooser = initializeJFileChooser(dicFileEditionDialogBox,"dic",
+					"Unicode Dela Dictionaries", "Dela");
+    	else if(extension.equals("csc"))
+			chooser = initializeJFileChooser(cscFileEditionDialogBox,"csc",
+					"Cascade Configuration Files", "CasSys");
+    	else
+    		chooser = getFileEditionDialogBox();
+    	return chooser;
     }
 
     public static JFileChooser getFst2UnambigDialogBox() {

--- a/unitex/src/fr/umlv/unitex/editor/FileEditionMenu.java
+++ b/unitex/src/fr/umlv/unitex/editor/FileEditionMenu.java
@@ -26,10 +26,12 @@ import java.awt.event.ActionListener;
 import javax.swing.JFileChooser;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
+import javax.swing.event.MenuEvent;
 
 import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.umlv.unitex.config.Config;
 import fr.umlv.unitex.frames.InternalFrameManager;
+import fr.umlv.unitex.frames.MenuAdapter;
 
 /**
  * Menu to handle file edition
@@ -43,12 +45,43 @@ public class FileEditionMenu extends JMenu {
 	public FileEditionMenu() {
 		super("File Edition");
 		fileManager = new FileManager();
-		final JMenuItem open = new JMenuItem("Open...");
-		open.addActionListener(new ActionListener() {
+		final JMenu open = new JMenu("Open...");
+		open.addMenuListener(new MenuAdapter() {
 			@Override
-			public void actionPerformed(ActionEvent e) {
-				openFile();
-				// save.setEnabled(true);
+			public void menuSelected(MenuEvent e) {
+				open.removeAll();
+				final JMenuItem txtItem = new JMenuItem("Text File");
+				txtItem.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent ev) {
+						openFile("txt");
+					}
+				});
+				final JMenuItem dicItem = new JMenuItem("Dictionary");
+				dicItem.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent ev) {
+						openFile("dic");
+					}
+				});
+				final JMenuItem cscItem = new JMenuItem("Cascade Configuration File");
+				cscItem.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent ev) {
+						openFile("csc");
+					}
+				});
+				final JMenuItem otherItem = new JMenuItem("Other Files");
+				otherItem.addActionListener(new ActionListener() {
+					@Override
+					public void actionPerformed(ActionEvent ev) {
+						openFile();
+					}
+				});
+				open.add(txtItem);
+				open.add(dicItem);
+				open.add(cscItem);
+				open.add(otherItem);
 			}
 		});
 		final JMenuItem newFile = new JMenuItem("New File");
@@ -87,6 +120,16 @@ public class FileEditionMenu extends JMenu {
 	 */
 	public static void openFile() {
 		final JFileChooser chooser = Config.getFileEditionDialogBox();
+		final int returnVal = chooser.showOpenDialog(null);
+		if (returnVal != JFileChooser.APPROVE_OPTION) {
+			// we return if the user has clicked on CANCEL
+			return;
+		}
+		fileManager.loadFile(chooser.getSelectedFile());
+	}
+	
+	public static void openFile(String extension) {
+		final JFileChooser chooser = Config.getFileEditionDialogBox(extension);
 		final int returnVal = chooser.showOpenDialog(null);
 		if (returnVal != JFileChooser.APPROVE_OPTION) {
 			// we return if the user has clicked on CANCEL


### PR DESCRIPTION
Includes specialized Open option for `*.txt`, `*.dic` and `*.csc` files. It also includes an option for opening other files. More file types can be added later, if required.