### PR TITLE
Resolving Issue#18: Pressing [Esc] closes the current dialog box

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -71,7 +71,7 @@
       <fileset dir="unitex" includes="build.xml"/>
     </subant>
 		<!-- Compile the java code from ${src} into ${build} -->
-		<echo message="classpaht=${dist}/Unitex.jar"/>
+		<echo message="classpath=${dist}/Unitex.jar"/>
 		<javac target="1.7" source="1.7" destdir="${build}" includeAntRuntime="false">
       <compilerarg value="-Xlint:-options"/>
       <src path="${src}"/>
@@ -135,7 +135,7 @@
 		</copy>
 	</target>
 
-  <target name="install-init">	
+  <target name="install-init">
 		<fail unless="env.UNITEX_BUILD_RELEASE_DIR" message="UNITEX_BUILD_RELEASE_DIR is not set. try `export UNITEX_BUILD_RELEASE_DIR=.`"/>
     <property name="unitexHome" value="${env.UNITEX_BUILD_RELEASE_DIR}"/>		
 		<property name="app" location="${unitexHome}/App" />

--- a/src/main/java/fr/gramlab/frames/MkdirDialog.java
+++ b/src/main/java/fr/gramlab/frames/MkdirDialog.java
@@ -8,15 +8,19 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 
-import fr.gramlab.Main;
+import fr.gramlab.*;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -53,6 +57,7 @@ public class MkdirDialog extends JDialog {
 			}
 		});
 		down.add(cancel);
+		KeyUtil.addEscListener(p, cancel);	
 		JButton ok=new JButton("Ok");
 		ok.addActionListener(new ActionListener() {
 			@Override
@@ -71,6 +76,8 @@ public class MkdirDialog extends JDialog {
 		});
 		down.add(ok);
 		main.add(down,BorderLayout.SOUTH);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		setContentPane(main);
 		pack();
 		FrameUtil.center(null,this);

--- a/src/main/java/fr/gramlab/frames/NewFileDialog.java
+++ b/src/main/java/fr/gramlab/frames/NewFileDialog.java
@@ -9,45 +9,49 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 
 import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProjectManager;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
 public class NewFileDialog extends JDialog {
 
-	JTextField text=new JTextField();
-	
+	JTextField text = new JTextField();
+
 	public NewFileDialog(final File file) {
-		super(Main.getMainFrame(),true);
-		JPanel main=new JPanel(new BorderLayout());
-		main.setBorder(BorderFactory.createEmptyBorder(10,10,10,10));
-		JPanel p=new JPanel(new GridBagLayout());
-		GridBagConstraints gbc=new GridBagConstraints();
-		gbc.fill=GridBagConstraints.BOTH;
-		gbc.weightx=1;
-		gbc.gridwidth=GridBagConstraints.REMAINDER;
-		p.add(new JLabel("Enter the name of the file (including its extension) to create in"),gbc);
-		p.add(new JLabel(file.getAbsolutePath()),gbc);
-		p.add(new JLabel(" "),gbc);
-		gbc.weightx=0;
-		gbc.gridwidth=1;
-		p.add(new JLabel("Name:"),gbc);
-		gbc.weightx=1;
-		gbc.gridwidth=GridBagConstraints.REMAINDER;
-		p.add(text,gbc);
-		main.add(p,BorderLayout.CENTER);
-		JPanel down=new JPanel(new FlowLayout());
-		JButton cancel=new JButton("Cancel");
+		super(Main.getMainFrame(), true);
+		JPanel main = new JPanel(new BorderLayout());
+		main.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+		JPanel p = new JPanel(new GridBagLayout());
+		GridBagConstraints gbc = new GridBagConstraints();
+		gbc.fill = GridBagConstraints.BOTH;
+		gbc.weightx = 1;
+		gbc.gridwidth = GridBagConstraints.REMAINDER;
+		p.add(new JLabel("Enter the name of the file (including its extension) to create in"), gbc);
+		p.add(new JLabel(file.getAbsolutePath()), gbc);
+		p.add(new JLabel(" "), gbc);
+		gbc.weightx = 0;
+		gbc.gridwidth = 1;
+		p.add(new JLabel("Name:"), gbc);
+		gbc.weightx = 1;
+		gbc.gridwidth = GridBagConstraints.REMAINDER;
+		p.add(text, gbc);
+		main.add(p, BorderLayout.CENTER);
+		JPanel down = new JPanel(new FlowLayout());
+		JButton cancel = new JButton("Cancel");
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -56,45 +60,42 @@ public class NewFileDialog extends JDialog {
 			}
 		});
 		down.add(cancel);
-		JButton ok=new JButton("Ok");
+		KeyUtil.addEscListener(p, cancel);
+		JButton ok = new JButton("Ok");
 		ok.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				if (text.getText().equals("")) {
-					JOptionPane.showMessageDialog(null,
-	                       "You must indicate a file name!", "Error",
-	                       JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "You must indicate a file name!", "Error",
+							JOptionPane.ERROR_MESSAGE);
 					return;
 				}
-				File f=new File(file,text.getText());
+				File f = new File(file, text.getText());
 				if (f.exists()) {
-					JOptionPane.showMessageDialog(null,
-		                       "A file with that name already exists !", "Error",
-		                       JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "A file with that name already exists !", "Error",
+							JOptionPane.ERROR_MESSAGE);
 					return;
 				}
 				try {
 					f.createNewFile();
 				} catch (IOException e1) {
-					JOptionPane.showMessageDialog(null,
-		                       "Cannot create this file !", "Error",
-		                       JOptionPane.ERROR_MESSAGE);
+					JOptionPane.showMessageDialog(null, "Cannot create this file !", "Error",
+							JOptionPane.ERROR_MESSAGE);
 					return;
 				}
 				setVisible(false);
 				dispose();
-				GlobalProjectManager.getAs(GramlabProjectManager.class)
-					.getProject(f).openFile(f,true);
+				GlobalProjectManager.getAs(GramlabProjectManager.class).getProject(f).openFile(f, true);
 			}
 		});
 		down.add(ok);
-		main.add(down,BorderLayout.SOUTH);
+		main.add(down, BorderLayout.SOUTH);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		setContentPane(main);
 		pack();
-		FrameUtil.center(null,this);
+		FrameUtil.center(null, this);
 		setVisible(true);
 	}
-	
-	
-	
+
 }

--- a/src/main/java/fr/gramlab/frames/NewGrfDialog.java
+++ b/src/main/java/fr/gramlab/frames/NewGrfDialog.java
@@ -8,17 +8,21 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 
 import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProjectManager;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 import fr.umlv.unitex.io.GraphIO;
 
@@ -56,6 +60,7 @@ public class NewGrfDialog extends JDialog {
 			}
 		});
 		down.add(cancel);
+		KeyUtil.addEscListener(p, cancel);
 		JButton ok=new JButton("Ok");
 		ok.addActionListener(new ActionListener() {
 			@Override
@@ -86,6 +91,8 @@ public class NewGrfDialog extends JDialog {
 		});
 		down.add(ok);
 		main.add(down,BorderLayout.SOUTH);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		setContentPane(main);
 		pack();
 		FrameUtil.center(null,this);

--- a/src/main/java/fr/gramlab/project/config/buildfile/ResultsConfigDialog.java
+++ b/src/main/java/fr/gramlab/project/config/buildfile/ResultsConfigDialog.java
@@ -13,6 +13,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -46,6 +47,9 @@ public class ResultsConfigDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/concordance/ConcordanceConfigDialog.java
+++ b/src/main/java/fr/gramlab/project/config/concordance/ConcordanceConfigDialog.java
@@ -13,6 +13,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -46,6 +47,9 @@ public class ConcordanceConfigDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/graph_compilation/ConfigureRepositoriesDialog.java
+++ b/src/main/java/fr/gramlab/project/config/graph_compilation/ConfigureRepositoriesDialog.java
@@ -31,6 +31,7 @@ import javax.swing.event.ListSelectionListener;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
 import fr.gramlab.project.config.maven.PomIO;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.LinkButton;
 import fr.umlv.unitex.config.NamedRepository;
 import fr.umlv.unitex.files.FileUtil;
@@ -68,6 +69,9 @@ public class ConfigureRepositoriesDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/locate/ConfigureVariableInjectionDialog.java
+++ b/src/main/java/fr/gramlab/project/config/locate/ConfigureVariableInjectionDialog.java
@@ -28,6 +28,7 @@ import javax.swing.event.ListSelectionListener;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.config.InjectedVariable;
 import fr.umlv.unitex.frames.FrameUtil;
 
@@ -61,6 +62,9 @@ public class ConfigureVariableInjectionDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/maven/EditDicsDialog.java
+++ b/src/main/java/fr/gramlab/project/config/maven/EditDicsDialog.java
@@ -30,6 +30,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -119,6 +120,9 @@ public class EditDicsDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/maven/EditFst2Dialog.java
+++ b/src/main/java/fr/gramlab/project/config/maven/EditFst2Dialog.java
@@ -19,6 +19,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -82,6 +83,9 @@ public class EditFst2Dialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/maven/MavenDialog.java
+++ b/src/main/java/fr/gramlab/project/config/maven/MavenDialog.java
@@ -43,6 +43,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
 import fr.gramlab.project.config.ProjectVersionableConfig;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.LinkButton;
 import fr.umlv.unitex.config.NamedRepository;
 import fr.umlv.unitex.files.FileUtil;
@@ -510,6 +511,9 @@ public class MavenDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		return pane;
 	}

--- a/src/main/java/fr/gramlab/project/config/maven/UpdateDependenciesDialog.java
+++ b/src/main/java/fr/gramlab/project/config/maven/UpdateDependenciesDialog.java
@@ -9,12 +9,15 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.KeyStroke;
 import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
@@ -49,6 +52,18 @@ public class UpdateDependenciesDialog extends JDialog {
 
 		setContentPane(createMainPanel());
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		p2.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		p2.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
+			}
+		});
 		setSize(400,600);
 		FrameUtil.center(getOwner(),this);
 		EventQueue.invokeLater(new Runnable() {

--- a/src/main/java/fr/gramlab/project/config/preprocess/ConfigBigPictureDialog.java
+++ b/src/main/java/fr/gramlab/project/config/preprocess/ConfigBigPictureDialog.java
@@ -53,6 +53,7 @@ public class ConfigBigPictureDialog extends JDialog {
 				setVisible(false);
 			}
 		});
+		KeyUtil.addEscListener(p, ok);
 		KeyUtil.addCRListener(ok);
 		down.add(ok);
 		p.add(down,BorderLayout.SOUTH);

--- a/src/main/java/fr/gramlab/project/config/preprocess/ConfigureProjectDialog.java
+++ b/src/main/java/fr/gramlab/project/config/preprocess/ConfigureProjectDialog.java
@@ -233,6 +233,7 @@ public class ConfigureProjectDialog extends JDialog {
 			}
 		});
 		p.add(nextOrFinish);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(cancel);
 		KeyUtil.addCRListener(previous);
 		KeyUtil.addCRListener(nextOrFinish);
@@ -263,6 +264,7 @@ public class ConfigureProjectDialog extends JDialog {
 			}
 		});
 		p.add(ok);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(cancel);
 		KeyUtil.addCRListener(ok);
 		return p;

--- a/src/main/java/fr/gramlab/project/config/preprocess/CreateProjectDialog.java
+++ b/src/main/java/fr/gramlab/project/config/preprocess/CreateProjectDialog.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
 import javax.swing.DefaultListCellRenderer;
@@ -29,12 +30,12 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.WindowConstants;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
-import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.gramlab.GramlabConfigManager;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
@@ -44,6 +45,7 @@ import fr.gramlab.project.config.maven.Artifact;
 import fr.gramlab.svn.SvnCheckoutDialog;
 import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.LinkButton;
+import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.umlv.unitex.config.ConfigManager;
 import fr.umlv.unitex.frames.FrameUtil;
 import fr.umlv.unitex.io.Encoding;
@@ -115,6 +117,7 @@ public class CreateProjectDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(ok);
 		KeyUtil.addCRListener(cancel);
 		p.add(down,BorderLayout.SOUTH);
@@ -201,6 +204,7 @@ public class CreateProjectDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(cancel);
 		KeyUtil.addCRListener(ok);
 		KeyUtil.addCRListener(name,ok);
@@ -271,6 +275,7 @@ public class CreateProjectDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(cancel);
 		KeyUtil.addCRListener(ok);
 		p.add(down,BorderLayout.SOUTH);
@@ -532,6 +537,7 @@ public class CreateProjectDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(cancel);
 		KeyUtil.addCRListener(ok);
 		KeyUtil.addCRListener(name,ok);
@@ -739,6 +745,7 @@ public class CreateProjectDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(p, cancel);
 		KeyUtil.addCRListener(cancel);
 		KeyUtil.addCRListener(ok);
 		KeyUtil.addCRListener(name,ok);

--- a/src/main/java/fr/gramlab/project/config/preprocess/fst2txt/PreprocessingStepDialog.java
+++ b/src/main/java/fr/gramlab/project/config/preprocess/fst2txt/PreprocessingStepDialog.java
@@ -24,6 +24,7 @@ import javax.swing.WindowConstants;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
 import fr.gramlab.project.config.maven.PomIO;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.files.FileUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
@@ -94,6 +95,9 @@ public class PreprocessingStepDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/project/config/rendering/RenderingConfigDialog.java
+++ b/src/main/java/fr/gramlab/project/config/rendering/RenderingConfigDialog.java
@@ -13,6 +13,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -46,6 +47,9 @@ public class RenderingConfigDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnAddDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnAddDialog.java
@@ -21,6 +21,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.gramlab.util.filelist.SelectableFileList;
 import fr.gramlab.util.filelist.SelectableFileListModel;
 import fr.umlv.unitex.console.Couple;
@@ -94,6 +95,9 @@ public class SvnAddDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnCheckoutDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnCheckoutDialog.java
@@ -33,6 +33,7 @@ import fr.gramlab.project.config.maven.MvnCommand;
 import fr.gramlab.project.config.maven.Pom;
 import fr.gramlab.project.config.maven.PomIO;
 import fr.gramlab.project.config.preprocess.CreateProjectDialog;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.console.Couple;
 import fr.umlv.unitex.files.FileUtil;
 import fr.umlv.unitex.frames.FrameUtil;
@@ -137,6 +138,9 @@ public class SvnCheckoutDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnCommitDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnCommitDialog.java
@@ -29,6 +29,7 @@ import javax.swing.tree.TreePath;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.console.Couple;
 import fr.umlv.unitex.frames.FrameUtil;
 import fr.umlv.unitex.process.ExecParameters;
@@ -122,6 +123,9 @@ public class SvnCommitDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnConflictDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnConflictDialog.java
@@ -14,6 +14,7 @@ import javax.swing.JRadioButton;
 import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.frames.FrameUtil;
 import fr.umlv.unitex.process.commands.SvnCommand.ResolveOp;
 import fr.umlv.unitex.svn.SvnConflict;
@@ -56,6 +57,9 @@ public class SvnConflictDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnDeleteDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnDeleteDialog.java
@@ -26,6 +26,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.gramlab.util.filelist.SelectableFileList;
 import fr.gramlab.util.filelist.SelectableFileListModel;
 import fr.umlv.unitex.console.Couple;
@@ -104,6 +105,7 @@ public class SvnDeleteDialog extends JDialog {
 			}
 		});
 		down.add(cancel);
+		KeyUtil.addEscListener(pane, cancel);
 		down.add(ok);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);

--- a/src/main/java/fr/gramlab/svn/SvnDeleteUrlDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnDeleteUrlDialog.java
@@ -18,6 +18,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.console.Couple;
 import fr.umlv.unitex.frames.FrameUtil;
 import fr.umlv.unitex.process.ExecParameters;
@@ -73,6 +74,9 @@ public class SvnDeleteUrlDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnRevertDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnRevertDialog.java
@@ -26,6 +26,7 @@ import javax.swing.WindowConstants;
 
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.gramlab.util.filelist.SelectableFileList;
 import fr.gramlab.util.filelist.SelectableFileListModel;
 import fr.umlv.unitex.console.Couple;
@@ -100,6 +101,9 @@ public class SvnRevertDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnShareDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnShareDialog.java
@@ -28,6 +28,7 @@ import javax.swing.border.BevelBorder;
 import fr.gramlab.GramlabConfigManager;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.console.Couple;
 import fr.umlv.unitex.frames.FrameUtil;
 import fr.umlv.unitex.process.ExecParameters;
@@ -123,6 +124,9 @@ public class SvnShareDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/svn/SvnUpdateDialog.java
+++ b/src/main/java/fr/gramlab/svn/SvnUpdateDialog.java
@@ -28,6 +28,7 @@ import javax.swing.WindowConstants;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProject;
 import fr.gramlab.project.config.maven.PomIO;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.console.Couple;
 import fr.umlv.unitex.files.FileUtil;
 import fr.umlv.unitex.frames.FrameUtil;
@@ -142,6 +143,9 @@ public class SvnUpdateDialog extends JDialog {
 		});
 		down.add(cancel);
 		down.add(ok);
+		KeyUtil.addEscListener(pane, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		pane.add(down,BorderLayout.SOUTH);
 		setContentPane(pane);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);

--- a/src/main/java/fr/gramlab/util/KeyUtil.java
+++ b/src/main/java/fr/gramlab/util/KeyUtil.java
@@ -1,10 +1,13 @@
 package fr.gramlab.util;
 
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
+import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.KeyStroke;
 
 public class KeyUtil {
 
@@ -27,5 +30,43 @@ public class KeyUtil {
 	
 	public static void addCRListener(JButton b) {
 		addCRListener(b,b);
+	}
+	
+	/**
+	 * Added by Mukarram Tailor
+	 * 
+	 * Pressing Esc on a focused dialog will act as clicking cancel
+	 * 
+	 */	
+	public static void addEscListener(JComponent c, final JButton b) {
+		c.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		c.getActionMap().put("closeTheDialog", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent cancel) {
+				b.doClick();
+			}
+		});
+	}
+	
+	/**
+	 * Added by Mukarram Tailor
+	 * 
+	 * Pressing Enter on a focused dialog will act as clicking OK
+	 * 
+	 */	
+	public static void addEnterListener(JComponent c, final JButton b) {
+		c.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ENTER"), "pressOK");
+		c.getActionMap().put("pressOK", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent next) {
+				b.doClick();
+			}
+		});
 	}
 }

--- a/src/main/java/fr/gramlab/workspace/ChangeWorkspaceDialog.java
+++ b/src/main/java/fr/gramlab/workspace/ChangeWorkspaceDialog.java
@@ -18,11 +18,12 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.WindowConstants;
 
-import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.gramlab.GramlabConfigManager;
 import fr.gramlab.Main;
 import fr.gramlab.project.GramlabProjectManager;
+import fr.gramlab.util.KeyUtil;
 import fr.umlv.unitex.LinkButton;
+import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
 import fr.umlv.unitex.frames.FrameUtil;
 
 @SuppressWarnings("serial")
@@ -116,6 +117,9 @@ public class ChangeWorkspaceDialog extends JDialog {
 		});
 		buttons.add(cancel);
 		p.add(buttons,gbc);
+		KeyUtil.addEscListener(p, cancel);
+		KeyUtil.addCRListener(ok);
+		KeyUtil.addCRListener(cancel);
 		p.setBorder(BorderFactory.createEmptyBorder(5,5,5,5));
 		return p;
 	}

--- a/unitex/src/fr/umlv/unitex/Unitex.java
+++ b/unitex/src/fr/umlv/unitex/Unitex.java
@@ -117,7 +117,6 @@ public class Unitex {
 								ConfigManager.setManager(new ConfigManager());
 								Config.initConfig(args.length == 1 ? args[0]
 										: null);
-
 								Preferences preferences = ConfigManager.getManager().getPreferences(null);
 								FontInfo menuFontInfo = preferences.getMenuFont();
 								setUIFont(new javax.swing.plaf.FontUIResource(menuFontInfo.getFont().toString(), Font.PLAIN, menuFontInfo.getSize()));

--- a/unitex/src/fr/umlv/unitex/editor/EditionTextArea.java
+++ b/unitex/src/fr/umlv/unitex/editor/EditionTextArea.java
@@ -20,12 +20,16 @@
  */
 package fr.umlv.unitex.editor;
 
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.util.regex.Pattern;
 
+import javax.swing.AbstractAction;
+import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
 import javax.swing.Timer;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -52,6 +56,19 @@ public class EditionTextArea extends JTextArea {
 			@Override
 			public void keyPressed(KeyEvent e) {
 				setModified();
+			}
+		});
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		this.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				System.out.println("Closed Dialog using ESC");
+				// btClose.doClick();
+				
 			}
 		});
 	}

--- a/unitex/src/fr/umlv/unitex/editor/EditionTextArea.java
+++ b/unitex/src/fr/umlv/unitex/editor/EditionTextArea.java
@@ -58,19 +58,6 @@ public class EditionTextArea extends JTextArea {
 				setModified();
 			}
 		});
-		// Added by Mukarram Tailor
-		// [Esc] key binding to close the dialog box
-		this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
-		this.getActionMap().put("closeTheDialog", new AbstractAction() {
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public void actionPerformed(ActionEvent escape) {
-				System.out.println("Closed Dialog using ESC");
-				// btClose.doClick();
-				
-			}
-		});
 	}
 
 	@Override

--- a/unitex/src/fr/umlv/unitex/editor/ui/AbstractFindpanel.java
+++ b/unitex/src/fr/umlv/unitex/editor/ui/AbstractFindpanel.java
@@ -96,8 +96,13 @@ abstract class AbstractFindpanel extends SearchPanel {
 		btReplaceAll = new JButton("Replace All");
 		btReplaceAll.setMnemonic('g');
 		p.add(btReplaceAll);
-		btClose = new JButton("Close");
+		//Edit By Mukarram Tailor
+		// btClose of Abstract class SearchPanel can be used
+		/*
+		btClose = new JButton("Close me.");   
 		btClose.setMnemonic('c');
+		p.add(btClose);
+		*/
 		p.add(btClose);
 		p01.add(p);
 		add(p01, BorderLayout.EAST);

--- a/unitex/src/fr/umlv/unitex/editor/ui/FindSentencePanel.java
+++ b/unitex/src/fr/umlv/unitex/editor/ui/FindSentencePanel.java
@@ -55,7 +55,7 @@ public class FindSentencePanel extends SearchPanel {
 		final JPanel p01 = new JPanel(new FlowLayout());
 		final JPanel p = new JPanel(new GridLayout(2, 1));
 		final JButton btFind = new JButton("Find");
-		// to have the same dimension betwin all panel buttons
+		// to have the same dimension between all panel buttons
 		btFind.setPreferredSize(new JButton("Count occurrences")
 				.getPreferredSize());
 		class findSentence implements ActionListener {

--- a/unitex/src/fr/umlv/unitex/editor/ui/SearchPanel.java
+++ b/unitex/src/fr/umlv/unitex/editor/ui/SearchPanel.java
@@ -21,11 +21,15 @@
 package fr.umlv.unitex.editor.ui;
 
 import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.AbstractAction;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 
 import fr.umlv.unitex.editor.EditionTextArea;
 
@@ -35,13 +39,27 @@ import fr.umlv.unitex.editor.EditionTextArea;
 abstract class SearchPanel extends JPanel {
 	final EditionTextArea text;
 	JButton btClose;
-
+	
 	SearchPanel(EditionTextArea text) {
 		super(new BorderLayout());
 		this.text = text;
-		// close button
 		btClose = new JButton("Close");
 		btClose.setMnemonic('c');
+		
+		//Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		this.getActionMap().put("closeTheDialog",
+	            new AbstractAction() {
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+	                public void actionPerformed(ActionEvent escape) {
+	                    //System.out.println("Closed Dialog using ESC");
+	                	btClose.doClick();
+	                }
+	            });
 	}
 
 	/**

--- a/unitex/src/fr/umlv/unitex/editor/ui/SearchPanel.java
+++ b/unitex/src/fr/umlv/unitex/editor/ui/SearchPanel.java
@@ -46,20 +46,18 @@ abstract class SearchPanel extends JPanel {
 		btClose = new JButton("Close");
 		btClose.setMnemonic('c');
 		
-		//Added by Mukarram Tailor
+		// Added by Mukarram Tailor
 		// [Esc] key binding to close the dialog box
 		this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
-		this.getActionMap().put("closeTheDialog",
-	            new AbstractAction() {
+		this.getActionMap().put("closeTheDialog", new AbstractAction() {
 
-					private static final long serialVersionUID = 1L;
+			private static final long serialVersionUID = 1L;
 
-					@Override
-	                public void actionPerformed(ActionEvent escape) {
-	                    //System.out.println("Closed Dialog using ESC");
-	                	btClose.doClick();
-	                }
-	            });
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				btClose.doClick();
+			}
+		});
 	}
 
 	/**

--- a/unitex/src/fr/umlv/unitex/frames/AboutDialog.java
+++ b/unitex/src/fr/umlv/unitex/frames/AboutDialog.java
@@ -2,15 +2,19 @@ package fr.umlv.unitex.frames;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.event.ActionEvent;
 import java.io.File;
 
+import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
 
@@ -25,70 +29,81 @@ import fr.umlv.unitex.text.BigTextArea;
  *
  */
 public class AboutDialog extends JDialog {
-  public AboutDialog(JFrame owner, String title, ImageIcon logo, String fileName, File disclaimersDir, File licensesDir) {
-    super(owner, "About " + "Unitex/GramLab");
+	public AboutDialog(JFrame owner, String title, ImageIcon logo, String fileName, File disclaimersDir,
+			File licensesDir) {
+		super(owner, "About " + "Unitex/GramLab");
 
-    final JPanel top = new JPanel(new BorderLayout());
-    final JPanel up = new JPanel(new BorderLayout());
-    final JPanel image = new JPanel(new BorderLayout());
-    image.setBorder(new EmptyBorder(4, 3, 1, 1));
-    image.add(new JLabel(logo));
-    up.add(image, BorderLayout.WEST);
-    final JPanel info = new JPanel(new BorderLayout());
-    info.setBorder(new TitledBorder("Disclaimer"));
-    
-    JTextField versionInfo = new JTextField();
+		final JPanel top = new JPanel(new BorderLayout());
+		final JPanel up = new JPanel(new BorderLayout());
+		final JPanel image = new JPanel(new BorderLayout());
+		image.setBorder(new EmptyBorder(4, 3, 1, 1));
+		image.add(new JLabel(logo));
+		up.add(image, BorderLayout.WEST);
+		final JPanel info = new JPanel(new BorderLayout());
+		info.setBorder(new TitledBorder("Disclaimer"));
 
-    String unitexToolLoggerSemVer = "?";
+		JTextField versionInfo = new JTextField();
 
-    // try to get the result of run 'UnitexToolLogger VersionInfo -s'
-    try {
-      unitexToolLoggerSemVer = Config.getUnitexToolLoggerSemVer(); 
-    } catch (final Exception e) {
-      // do nothing  
-    }
-    
-    versionInfo = new JTextField(Version.VERSION_TITLE   + ": "       +
-                                 Version.VERSION_SEMVER  + " | "      +
-                                 "UnitexToolLogger"      + ": "       +
-                                 unitexToolLoggerSemVer);
+		String unitexToolLoggerSemVer = "?";
 
-    versionInfo.setEditable(false);
-    up.add(versionInfo, BorderLayout.NORTH);
-        
-    BigTextArea disclaimerContent = new BigTextArea();
-    if(disclaimersDir.exists() && disclaimersDir.isDirectory()) {
-      File disclaimer = new File(disclaimersDir, fileName);
-      if(disclaimer.exists()) {
-        disclaimerContent = new BigTextArea(disclaimer);
-        int disclaimerHeight = image.getHeight() > 150 ? image.getHeight() : 150;
-        disclaimerContent.setPreferredSize(new Dimension(400, disclaimerHeight));
-      }
-    }
-    info.add(disclaimerContent, BorderLayout.CENTER);
-    
-    up.add(info, BorderLayout.CENTER);
-    top.add(up, BorderLayout.NORTH);
-    
-    final JTabbedPane licensesPanel = new JTabbedPane();
-    
-    if(licensesDir.exists() && licensesDir.isDirectory()) {
-      File[] licenses = licensesDir.listFiles();
-      for(File license : licenses) {
-        if(license.getName().contains(".txt")) {
-          String[] licenseName = license.getName().split(".txt");
-          BigTextArea licenseContent = new BigTextArea(new File(licensesDir, license.getName()));
-          licensesPanel.add(licenseContent, licenseName[0]);
-        }
-      }
-    }
-    
-    top.add(licensesPanel, BorderLayout.CENTER);
-    setContentPane(top);
-    licensesPanel.setPreferredSize(new Dimension(500, 300));
-    pack();
-    setDefaultCloseOperation(HIDE_ON_CLOSE);
-    setLocationRelativeTo(UnitexFrame.mainFrame);
-    setVisible(true);
-  }
+		// try to get the result of run 'UnitexToolLogger VersionInfo -s'
+		try {
+			unitexToolLoggerSemVer = Config.getUnitexToolLoggerSemVer();
+		} catch (final Exception e) {
+			// do nothing
+		}
+
+		versionInfo = new JTextField(Version.VERSION_TITLE + ": " + Version.VERSION_SEMVER + " | " + "UnitexToolLogger"
+				+ ": " + unitexToolLoggerSemVer);
+
+		versionInfo.setEditable(false);
+		up.add(versionInfo, BorderLayout.NORTH);
+
+		BigTextArea disclaimerContent = new BigTextArea();
+		if (disclaimersDir.exists() && disclaimersDir.isDirectory()) {
+			File disclaimer = new File(disclaimersDir, fileName);
+			if (disclaimer.exists()) {
+				disclaimerContent = new BigTextArea(disclaimer);
+				int disclaimerHeight = image.getHeight() > 150 ? image.getHeight() : 150;
+				disclaimerContent.setPreferredSize(new Dimension(400, disclaimerHeight));
+			}
+		}
+		info.add(disclaimerContent, BorderLayout.CENTER);
+
+		up.add(info, BorderLayout.CENTER);
+		top.add(up, BorderLayout.NORTH);
+
+		final JTabbedPane licensesPanel = new JTabbedPane();
+
+		if (licensesDir.exists() && licensesDir.isDirectory()) {
+			File[] licenses = licensesDir.listFiles();
+			for (File license : licenses) {
+				if (license.getName().contains(".txt")) {
+					String[] licenseName = license.getName().split(".txt");
+					BigTextArea licenseContent = new BigTextArea(new File(licensesDir, license.getName()));
+					licensesPanel.add(licenseContent, licenseName[0]);
+				}
+			}
+		}
+
+		top.add(licensesPanel, BorderLayout.CENTER);
+		setContentPane(top);
+		licensesPanel.setPreferredSize(new Dimension(500, 300));
+		pack();
+		setDefaultCloseOperation(HIDE_ON_CLOSE);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		top.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		top.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
+			}
+		});
+		setLocationRelativeTo(UnitexFrame.mainFrame);
+		setVisible(true);
+	}
 }

--- a/unitex/src/fr/umlv/unitex/frames/CheckDicFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/CheckDicFrame.java
@@ -29,9 +29,11 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JInternalFrame;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
+import javax.swing.KeyStroke;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
 
@@ -105,6 +107,18 @@ public class CheckDicFrame extends JInternalFrame {
 			}
 		};
 		final JButton CANCEL = new JButton(cancelAction);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		rightPanel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		rightPanel.getActionMap().put("closeTheDialog", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				CANCEL.doClick();
+			}
+		});
 		rightPanel.add(GO);
 		rightPanel.add(CANCEL);
 		return rightPanel;

--- a/unitex/src/fr/umlv/unitex/frames/ConsoleFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/ConsoleFrame.java
@@ -24,16 +24,20 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultCellEditor;
 import javax.swing.ImageIcon;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -162,6 +166,18 @@ public class ConsoleFrame extends TabbableInternalFrame {
 		setContentPane(top);
 		setBounds(100, 100, 600, 400);
 		setDefaultCloseOperation(HIDE_ON_CLOSE);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		top.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		top.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
+			}
+		});
 	}
 
 	/**

--- a/unitex/src/fr/umlv/unitex/frames/DelaFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/DelaFrame.java
@@ -33,12 +33,15 @@ import java.text.ParseException;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
 import javax.swing.JPanel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
+import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.Timer;
@@ -87,6 +90,19 @@ public class DelaFrame extends KeyedInternalFrame<File> {
 		pack();
 		setBounds(100, 100, 500, 500);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+		//TODO : Change the action to Minimize rather than close on pressing Esc	
+		/* Added by Mukarram Tailor
+		  [Esc] key binding to close the dialog box */
+		top.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		top.getActionMap().put("closeTheDialog", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+			}
+		});
 		addInternalFrameListener(new InternalFrameAdapter() {
 			@Override
 			public void internalFrameClosing(InternalFrameEvent e) {

--- a/unitex/src/fr/umlv/unitex/frames/FileEditionTextFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/FileEditionTextFrame.java
@@ -34,6 +34,7 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -196,6 +197,19 @@ public class FileEditionTextFrame extends TabbableInternalFrame {
 		pack();
 		setBounds(100, 100, 800, 600);
 		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+		//TODO : Change the action to Minimize rather than close on pressing Esc
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		top.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		top.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
+			}
+		});
 		addInternalFrameListener(new InternalFrameAdapter() {
 			@Override
 			public void internalFrameClosing(InternalFrameEvent e) {

--- a/unitex/src/fr/umlv/unitex/frames/GraphDiffFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphDiffFrame.java
@@ -23,14 +23,17 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
+import javax.swing.AbstractAction;
 import javax.swing.BoxLayout;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.KeyStroke;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -71,6 +74,19 @@ public class GraphDiffFrame extends TabbableInternalFrame {
 							.getFrameManagerAs(InternalFrameManager.class)
 							.newGraphFrame(dest.getGrf());
 				}
+			}
+		});
+		//TODO : Change the action to Minimize rather than close on pressing Esc
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		main.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		main.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
 			}
 		});
 		final JPanel p = buildSynchronizedScrollPanes(basePane, destPane);

--- a/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageOutputStream;
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -50,6 +51,7 @@ import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -58,6 +60,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
@@ -225,6 +228,19 @@ public class GraphFrame extends KeyedInternalFrame<File> {
 		mainPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
 		final JPanel top = new JPanel(new BorderLayout());
 		top.add(buildTextPanel(), BorderLayout.NORTH);
+		//TODO : Change the action to Minimize rather than close on pressing Esc
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		top.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		top.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
+			}
+		});
 		graphicalZone = new GraphicalZone(g, getBoxContentEditor(), this, null);
 		graphicalZone.addGraphListener(new GraphListener() {
 			@Override

--- a/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
@@ -115,7 +115,7 @@ public class GraphFrame extends KeyedInternalFrame<File> {
 	JScrollPane grfListScroll = new JScrollPane(grfList);
 	JPanel grfListPanel;
 	JLabel grfListLabel = new JLabel();
-
+	
 	public GraphicalZone getGraphicalZone() {
 		return graphicalZone;
 	}

--- a/unitex/src/fr/umlv/unitex/frames/GraphPresentationDialog.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphPresentationDialog.java
@@ -38,10 +38,12 @@ import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JColorChooser;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
+import javax.swing.KeyStroke;
 import javax.swing.SwingConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
@@ -116,6 +118,18 @@ class GraphPresentationDialog extends JDialog {
 		panel.add(upPanel, gbc);
 		panel.add(constructAntialiasingPanel(), gbc);
 		panel.add(downPanel, gbc);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		panel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		panel.getActionMap().put("closeTheDialog", new AbstractAction() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+
+			}
+		});
 		return panel;
 	}
 

--- a/unitex/src/fr/umlv/unitex/frames/InflectFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/InflectFrame.java
@@ -31,11 +31,13 @@ import javax.swing.Action;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JInternalFrame;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.border.TitledBorder;
 
 import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
@@ -78,6 +80,18 @@ public class InflectFrame extends JInternalFrame {
 		final JPanel panel = new JPanel(new BorderLayout());
 		panel.add(constructUpPanel(), BorderLayout.CENTER);
 		panel.add(constructDownPanel(), BorderLayout.SOUTH);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		panel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		panel.getActionMap().put("closeTheDialog", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+			}
+		});
 		return panel;
 	}
 

--- a/unitex/src/fr/umlv/unitex/frames/InternalFrameManager.java
+++ b/unitex/src/fr/umlv/unitex/frames/InternalFrameManager.java
@@ -105,7 +105,8 @@ public abstract class InternalFrameManager implements FrameManager {
 	private final GraphAlignmentDialogFactory graphAlignmentDialogFactory = new GraphAlignmentDialogFactory();
 	private final GraphSizeDialogFactory graphSizeDialogFactory = new GraphSizeDialogFactory();
 	private final ExportTextAsPOSListDialogFactory exportTextAsPOSListDialogFactory = new ExportTextAsPOSListDialogFactory();
-
+	
+	
 	public InternalFrameManager(JDesktopPane desktop) {
 		this.desktop = desktop;
 	}
@@ -227,6 +228,7 @@ public abstract class InternalFrameManager implements FrameManager {
 		});
 		setup(t, true);
 		fireTextFrameOpened(taggedText);
+		System.out.println("Text Frame opened");
 		return t;
 	}
 

--- a/unitex/src/fr/umlv/unitex/frames/ProcessInfoFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/ProcessInfoFrame.java
@@ -32,12 +32,14 @@ import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
+import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
 import fr.umlv.unitex.console.Couple;
@@ -136,6 +138,18 @@ public class ProcessInfoFrame extends JInternalFrame {
 			}
 		};
 		cancel = new JButton(cancelAction);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		top.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		top.getActionMap().put("closeTheDialog", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				cancel.doClick();
+			}
+		});
 		final JPanel buttons = new JPanel(new GridLayout(1, 2));
 		buttons.add(ok);
 		buttons.add(cancel);

--- a/unitex/src/fr/umlv/unitex/frames/Seq2GrfFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/Seq2GrfFrame.java
@@ -28,11 +28,13 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
@@ -40,6 +42,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.border.BevelBorder;
 
@@ -192,6 +195,18 @@ public class Seq2GrfFrame extends JInternalFrame {
 			}
 		});
 		p.add(go,gbc);
+		// Added by Mukarram Tailor
+		// [Esc] key binding to close the dialog box
+		p.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke("ESCAPE"), "closeTheDialog");
+		p.getActionMap().put("closeTheDialog", new AbstractAction() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public void actionPerformed(ActionEvent escape) {
+				setVisible(false);
+			}
+		});
 		return p;
 	}
 	

--- a/unitex/src/fr/umlv/unitex/frames/TextFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/TextFrame.java
@@ -23,14 +23,18 @@ package fr.umlv.unitex.frames;
 import java.awt.BorderLayout;
 import java.awt.ComponentOrientation;
 import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.InternalFrameAdapter;
 import javax.swing.event.InternalFrameEvent;


### PR DESCRIPTION
An [Esc] Hotkey binding was added to all the dialog boxes as required  by [Issue#18](https://github.com/UnitexGramLab/gramlab-ide/issues/18). 
File Editor, Graph editor and Dictionary dialog also close on [Esc], but this can be changed to minimize in future.