### PR TITLE
feature #16: Allow to create a non-existent sub-graph

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
@@ -39,6 +39,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import javax.imageio.ImageIO;
@@ -1354,6 +1356,37 @@ public class GraphFrame extends KeyedInternalFrame<File> {
 
 	public boolean saveAsGraph() {
 		return saveAsGraph(false);
+	}
+	
+	/**
+	 * A method to provide "Save As /foo/bar.grf" functionality to a graph.
+	 * This method saves current graph frame at a particular location with the specified name.
+	 * 
+	 * @author Mukarram Tailor
+	 * @param  path
+	 * 		the absolute path(to be saved at) of .grf file 
+	 * @param  validated
+	 * 		boolean stating validation of content of .grf file
+	 * @return
+	 * 		true if saveAs operation is successful, else false
+	 */
+	public boolean saveAsGraph(String path, boolean validated){
+		if(!validated) {
+			if(graphicalZone.text.isModified()){
+				if(!graphicalZone.text.validateContent()){
+					return false;
+				}
+			}
+		}
+		final GraphIO g = new GraphIO(graphicalZone);
+		Path p = Paths.get(path);
+		File newFile = p.toFile();
+		if (newFile == null) {
+			return false;
+		}
+		g.saveGraph(newFile);
+		setGraph(newFile, newFile, false);
+		return true;
 	}
 	
 	private boolean saveAsGraph(boolean validated) {


### PR DESCRIPTION
Issue#16 was resolved.
### Steps:
1. Create a box in a graph with a non-existing sub graph. It turns red.
2. Right-click on the red box and select `Open subgraph` .

### **Earlier**
3. Error dialog stating` the sub graph does not exist` appears. 
![screenshot from 2016-05-18 16 22 37](https://cloud.githubusercontent.com/assets/9568504/15356347/c46dda38-1d15-11e6-9934-19c037574d82.png)


### **Now**
3. Dialog asks whether to `create a new graph with same name?` with options `Yes` and `No`
![screenshot from 2016-05-18 16 21 05](https://cloud.githubusercontent.com/assets/9568504/15356225/1ee866d2-1d15-11e6-92c4-433ee4f028f8.png)
4. Opens an empty graph with the name.
![screenshot from 2016-05-18 16 21 18](https://cloud.githubusercontent.com/assets/9568504/15356229/25d5644a-1d15-11e6-8750-4b3b24cf1907.png)
