### PR TITLE
Refactor: Spelling fix & remove redundant code

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -60,7 +60,7 @@
       <fileset dir="unitex" includes="build.xml"/>
     </subant>
 		<!-- Compile the java code from ${src} into ${build} -->
-		<echo message="classpaht=${dist}/Unitex.jar"/>
+		<echo message="classpath=${dist}/Unitex.jar"/>
 		<javac target="1.6" source="1.6" srcdir="${src}" destdir="${build}" classpath="${dist}/Unitex.jar" includeAntRuntime="false"/>
 	</target>
 

--- a/src/main/java/fr/gramlab/project/GramlabProject.java
+++ b/src/main/java/fr/gramlab/project/GramlabProject.java
@@ -1374,11 +1374,6 @@ public class GramlabProject implements Project, Comparable<GramlabProject> {
 				GlobalProjectManager.getAs(GramlabProjectManager.class).setCurrentProject(this);
 				return;
 			}
-			if (file.getName().endsWith(".dic")) {
-				openDicFile(file);
-				GlobalProjectManager.getAs(GramlabProjectManager.class).setCurrentProject(this);
-				return;
-			}
 		}
 		if (Encoding.getEncoding(file) == null) {
 			JOptionPane.showMessageDialog(null,


### PR DESCRIPTION
#### Minor Refactoring:
- Spelling of classpath was corrected in [build.xml](https://github.com/UnitexGramLab/gramlab-ide/blob/master/build.xml#L63)
- Redundant if statement was removed from [GramlabProject.java](https://github.com/UnitexGramLab/gramlab-ide/blob/master/src/main/java/fr/gramlab/project/GramlabProject.java#L1377)