### PR TITLE
Update the LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -50,6 +50,11 @@ authors.
   - http://apache.mirrors.ovh.net/ftp.apache.org/dist/xerces/j/source/
   - [Apache Software License version 2.0][Apache-2.0]
 
+* juniversalchardet
+  - Java port of universalchardet from Mozilla
+  - https://code.google.com/archive/p/juniversalchardet/source/default/source
+  - [GNU Lesser General Public License version 2.1][LGPLv2]
+
 Some of those third-party packages are under licenses which require that the 
 copyright and license notices are included when distributing the code in binary
 form. These notices are available in the `licenses` directory.


### PR DESCRIPTION
As stated here : https://code.google.com/archive/p/juniversalchardet/ (5. License), the library can be used under the terms of the GNU Lesser General Public License 2.1 or later
