### PR TITLE
[fix #103] Change 'explore graph paths' option description

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
@@ -133,9 +133,9 @@ public class GraphPathFrame extends JInternalFrame {
 		final JPanel top1 = new JPanel(new FlowLayout(FlowLayout.LEFT));
 		final ButtonGroup pathWithSubGraph = new ButtonGroup();
 		
-		onlyPaths = new JRadioButton("Only paths", true);
+		onlyPaths = new JRadioButton("Explore recursively", true);
 		exploreRecursively = new JRadioButton(
-				"Do not explore subgraphs recursively");
+				"Explore each subgraph independently");
 		
 		// issue #61 add listeners to change default output file name based on user selection
 		onlyPaths.addActionListener(new ActionListener() {

--- a/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
@@ -132,10 +132,10 @@ public class GraphPathFrame extends JInternalFrame {
 		top.add(constructDownPanel());
 		final JPanel top1 = new JPanel(new FlowLayout(FlowLayout.LEFT));
 		final ButtonGroup pathWithSubGraph = new ButtonGroup();
-		final JLabel explorationLabel = new JLabel("Calls to subgraphs: ");
-		onlyPaths = new JRadioButton("Explore recursively", true);
+		final JLabel explorationLabel = new JLabel("Explore subgraphs: ");
+		onlyPaths = new JRadioButton("Recursively", true);
 		exploreRecursively = new JRadioButton(
-				"Explore each subgraph independently");
+				"Independently, printing names of called subgraphs");
 		
 		// issue #61 add listeners to change default output file name based on user selection
 		onlyPaths.addActionListener(new ActionListener() {

--- a/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
@@ -132,7 +132,7 @@ public class GraphPathFrame extends JInternalFrame {
 		top.add(constructDownPanel());
 		final JPanel top1 = new JPanel(new FlowLayout(FlowLayout.LEFT));
 		final ButtonGroup pathWithSubGraph = new ButtonGroup();
-		
+		final JLabel explorationLabel = new JLabel("Calls to subgraphs: ");
 		onlyPaths = new JRadioButton("Explore recursively", true);
 		exploreRecursively = new JRadioButton(
 				"Explore each subgraph independently");
@@ -153,6 +153,7 @@ public class GraphPathFrame extends JInternalFrame {
 		
 		pathWithSubGraph.add(onlyPaths);
 		pathWithSubGraph.add(exploreRecursively);
+		top1.add(explorationLabel);
 		top1.add(onlyPaths);
 		top1.add(exploreRecursively);
 		top.add(top1);


### PR DESCRIPTION
Change the options' descriptions to explicit what they actually do.