### PR TITLE
[minor fix #107] Resolve compilation problem with Cascade

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/TransducerListConfigurationFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/TransducerListConfigurationFrame.java
@@ -701,7 +701,8 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 						commands.addCommand(new Grf2Fst2Command()
 								.grf(graphFile)
 								.enableLoopAndRecursionDetection(true)
-								.alphabetTokenization(f_alphabet));
+								.alphabetTokenization(f_alphabet)
+                .repositories());
 
 					}
 					


### PR DESCRIPTION
**Description**

Solves the porblem that occur in the cascade edition interface, when compiling a graph which contains a sub-graph located in the defined "graph repository".

**Other information**

See issue #107 .


