### PR TITLE
[fix #77] Resolve a null pointer exception ExportTextAsPOSListDialog

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/ExportTextAsPOSListDialog.java
+++ b/unitex/src/fr/umlv/unitex/frames/ExportTextAsPOSListDialog.java
@@ -29,8 +29,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 
 import javax.swing.JDialog;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 
@@ -117,6 +119,7 @@ public class ExportTextAsPOSListDialog extends JDialog {
 				final File sentenceTok = new File(sntDir, "foo.tok");
 				final TfstTableModel model = new TfstTableModel(filter,
 						delafStyle);
+				final ArrayList<Integer> errorList = new ArrayList<>();
 				try {
 					final OutputStreamWriter writer = encoding
 							.getOutputStreamWriter(output);
@@ -130,6 +133,10 @@ public class ExportTextAsPOSListDialog extends JDialog {
 						final String text = readSentenceText(sentenceText);
 						TokensInfo.loadTokensInfo(sentenceTok, text);
 						final GraphIO g = GraphIO.loadGraph(tmpGrf, true, true);
+						if (g == null) {
+							errorList.add(i);
+							continue;
+						}
 						model.init(g.getBoxes());
 						if (model.getRowCount() == 0) {
 							/*
@@ -144,7 +151,7 @@ public class ExportTextAsPOSListDialog extends JDialog {
 							for (int j = 0; j < model.getRowCount(); j++) {
 								final TokenTags t = model.getTokenTags(j);
 								UnicodeIO.writeString(writer, t.toString()
-										+ " ");
+									+ " ");
 							}
 						/* And we add a sentence delimiter */
 						UnicodeIO.writeString(writer, "{S}\n");
@@ -189,6 +196,17 @@ public class ExportTextAsPOSListDialog extends JDialog {
 					} catch (final InvocationTargetException e) {
 						e.printStackTrace();
 					}
+				}
+				
+				if (errorList.size() > 0) {
+					StringBuilder sb = new StringBuilder("The following sentence(s) couldn't "
+							+ "be exported: \n");
+					for(int j = 0; j < errorList.size(); j++) {
+						sb.append("Sentence #").append(errorList.get(j)).append("\n");
+					}
+					JOptionPane.showMessageDialog(null,
+							sb.toString(), "Warning",
+							JOptionPane.WARNING_MESSAGE);
 				}
 			}
 		}).start();

--- a/unitex/src/fr/umlv/unitex/frames/ExportTextAsPOSListDialog.java
+++ b/unitex/src/fr/umlv/unitex/frames/ExportTextAsPOSListDialog.java
@@ -198,7 +198,7 @@ public class ExportTextAsPOSListDialog extends JDialog {
 					}
 				}
 				
-				if (errorList.size() > 0) {
+				if (!errorList.isEmpty()) {
 					StringBuilder sb = new StringBuilder("The following sentence(s) couldn't "
 							+ "be exported: \n");
 					for(int j = 0; j < errorList.size(); j++) {


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above. 
Note that the Title must conform to the subject of a commit message

See the **Commit Message Guidelines** for more information:
https://github.com/UnitexGramLab/unitex-doc-contributor-guidelines/blob/master/pages/05.guidelines/01.commits/docs.md 
-->

## Description
<!-- Describe your changes in detail -->
Solves a problem occurring when trying to export an automaton as a POS list on some corpora. Initially the process would fail when reaching a particular sentence and stop in the middle. With these changes, the process skips those sentences and completes. A warning message is then displayed to notify the user which sentences have been skipped.


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
See issue #77 and its attached file.
It seems the problem stems from the fact that there's an error in the construction of the tfst file: the line 12033 contains the sequence  *@{*  which doesn't appear in sentence 36, moreover, there seems to be an error in the bounds as we can see on line 12034:  *@36.0.-6-36.2.1*  with a negative bound (although it is possible to have negative bounds, here, it seems to cause an error).

The same error can be observed for the following sentences: 698, 750 and 1247.

Because of that, Unitex is unable to load the graphs corresponding to these sentences resulting in a null pointer exception.


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
All of my tests were done under Linux environment (Distribution Debian 9). I tested my changes on the file provided in issue #77. The exportation completes without fail and the correct warning message is displayed at the end.
I also made sure the behavior of the program is still the same when working with correct corpora.


<!-- If this project features any kind of testing (unit, integration, regression), uncomment and complete the following checklist -->
<!-- - [ ] I have added tests to cover my changes  -->
<!-- - [ ] All new and existing tests passed  -->

## Screenshots:
![erreur_tfst](https://user-images.githubusercontent.com/38852020/42158335-699e7516-7df0-11e8-89c8-49fe39f35c9a.png)

Here is the tag for sentence 36 which seems to cause the problem.

## Type of files
<!-- What type of files does your pull request modify? Put an `x` in the box (only the mainly type) that apply: -->
- [ ] `bin`: Binary files
- [ ] `ci`: Continuous integration files
- [ ] `doc`: Documentation files
- [x] Plain-text source code files

## Level of change
<!-- What level of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `break`: Breaking change
- [ ] `exp`: Experimental change
- [ ] `tmp`: Temporal change
- [ ] `major`: Major change
- [ ] `minor`: Minor change
- [ ] `sec`: Vulnerability-related change
- [x] None of the above (normal change)

## Type of change
<!-- What type of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `deprecat`: Deprecation of a once-stable feature
- [ ] `enhance`: Enhancement in existing functionality
- [x] `fix`: Bug fix
- [ ] `feature`: New feature
- [ ] `hotfix`: Hotfix for bugs
- [ ] `refactor`: Improve coding style, comments
- [ ] `remove`: Remove a feature

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code compiles
- [x] My code follows the code style of this project
- [ ] My code includes javadoc/doxygen where appropriate
- [ ] My code is well factored, so that there is not repetitive code in the wild
- [x] My code does not require a change in the documentation, if so I already opened an issue to list the changes
- [x] I have read the **CONTRIBUTING** document
- [x] I have read the **Commit Message Guidelines**
- [x] I understand that all commits on my pull request will be squashed to a single good one
<!-- Check if all the points above have an `x`, if so you can submit your PR for review -->
