### PR TITLE
[minor feature] End generalization boxes

### DIFF
--- a/unitex/src/fr/umlv/unitex/graphrendering/GraphicalZone.java
+++ b/unitex/src/fr/umlv/unitex/graphrendering/GraphicalZone.java
@@ -308,7 +308,7 @@ public class GraphicalZone extends GenericGraphicalZone implements Printable {
                     public void actionPerformed(ActionEvent e) {
                         surroundWithBoxes(
                             (ArrayList<GenericGraphBox>) selectedBoxes.clone(),
-                            "$G/{", null);
+                            "$G/{", "<E>/}");
                     }
                 };
                 addGenericGraphIndicator.setEnabled(false);


### PR DESCRIPTION
This commit adds a closing box at the end of a generalization part when clicking the "$G" button (to match the new comming syntax without impacting the previous one).