### PR TITLE
Refactor/minor improvements

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/FileEditionTextFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/FileEditionTextFrame.java
@@ -12,7 +12,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
@@ -49,6 +49,7 @@ import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.InternalFrameAdapter;
 import javax.swing.event.InternalFrameEvent;
+import javax.swing.filechooser.FileFilter;
 
 import fr.umlv.unitex.MyCursors;
 import fr.umlv.unitex.common.project.manager.GlobalProjectManager;
@@ -56,11 +57,12 @@ import fr.umlv.unitex.config.ConfigManager;
 import fr.umlv.unitex.editor.EditionTextArea;
 import fr.umlv.unitex.editor.FileEditionMenu;
 import fr.umlv.unitex.editor.FileManager;
+import fr.umlv.unitex.files.PersonalFileFilter;
 import fr.umlv.unitex.utils.KeyUtil;
 
 /*
  * This class is used to display the text
- *  
+ *
  */
 public class FileEditionTextFrame extends TabbableInternalFrame {
 	/**
@@ -372,6 +374,9 @@ public class FileEditionTextFrame extends TabbableInternalFrame {
 	void saveFile(File f) {
 		if (f == null) {
 			final JFileChooser chooser = new JFileChooser();
+			chooser.addChoosableFileFilter(new PersonalFileFilter("txt", "Text File"));
+			chooser.addChoosableFileFilter(new PersonalFileFilter("dic", "Dictionary file"));
+			chooser.addChoosableFileFilter(new PersonalFileFilter("csc", "CasSys configuration file"));
 			if (file!=null) {
 				chooser.setCurrentDirectory(file.getParentFile());
 			} else {
@@ -386,6 +391,17 @@ public class FileEditionTextFrame extends TabbableInternalFrame {
 				return;
 			}
 			f = chooser.getSelectedFile();
+			final FileFilter selectedFilter = chooser.getFileFilter();
+			
+			if (selectedFilter instanceof PersonalFileFilter) {
+			    final PersonalFileFilter selectedPersonalFilter = (PersonalFileFilter) selectedFilter;
+          final String selectedExtension = selectedPersonalFilter.getExtension();
+          final String selectedFileName = f.getAbsolutePath();
+          
+          if (!selectedFileName.endsWith(selectedExtension)) {
+            f = new File(selectedFileName + selectedExtension);
+          }
+      }
 		}
 		this.file = f;
 		setTitle(f.getAbsolutePath());
@@ -399,7 +415,7 @@ public class FileEditionTextFrame extends TabbableInternalFrame {
 
 	/**
 	 * Returns the text.
-	 * 
+	 *
 	 * @return MyTextArea
 	 */
 	public EditionTextArea getText() {

--- a/unitex/src/fr/umlv/unitex/frames/TransducerListConfigurationFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/TransducerListConfigurationFrame.java
@@ -106,7 +106,7 @@ import fr.umlv.unitex.utils.KeyUtil;
  * <p/>
  * <p/>
  * </P>
- * 
+ *
  * @author David Nott
  */
 public class TransducerListConfigurationFrame extends JInternalFrame implements
@@ -345,9 +345,9 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 						try {
 							final ConfigurationFileAnalyser cfa = new ConfigurationFileAnalyser(
 									line);
-							// ***final Object[] o = { DataList.UNRANKED, cfa.getFileName(), 
+							// ***final Object[] o = { DataList.UNRANKED, cfa.getFileName(),
 							// ***		cfa.isMergeMode(), cfa.isReplaceMode(), cfa.isDisabled(), cfa.isStar() };
-							final Object[] o = { DataList.UNRANKED, cfa.isDisabled(), cfa.getFileName(), 
+							final Object[] o = { DataList.UNRANKED, cfa.isDisabled(), cfa.getFileName(),
 										cfa.isMergeMode(), cfa.isReplaceMode(), cfa.isStar(), cfa.isGeneric() };
 							tableModel.addRow(o);
 							if (cfa.isCommentFound()) {
@@ -403,7 +403,7 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 	 * Constructs and return a panel of buttons for user interaction with the
 	 * table. <code>ConfigurationFrame</code> is added as listener for all
 	 * buttons.
-	 * 
+	 *
 	 * @return the panel with all the buttons
 	 */
 	JPanel create_panel() {
@@ -503,7 +503,7 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 	 * or <code>bottom</code>. Except with the <code>delete</code> event,
 	 * selection is kept on the same logical row (to oppose to the same row
 	 * index). When a selected row is moved, selection moves with it.
-	 * 
+	 *
 	 * @param a
 	 *            Action event notified to this class.
 	 */
@@ -599,7 +599,7 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 			
 			final File selected_file = fileBrowse.getSelectedFile();
 			
-						
+			
 			
 			if (selected_file != null) {
 				try {
@@ -630,7 +630,7 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 			if (table.getSelectedRow() != -1) {
 				final TransducerListTableModel model = (TransducerListTableModel) table.getModel();
 				final File graph = new File(Config.getCurrentGraphDir(),(String) model.getValueAt(
-							table.getSelectedRow(), 
+							table.getSelectedRow(),
 							model.getNameIndex()));
 				viewGraph(graph);
 			} else {
@@ -780,8 +780,14 @@ public class TransducerListConfigurationFrame extends JInternalFrame implements
 
 	void saveListToFile() {
 		try {
-			final BufferedWriter fw = new BufferedWriter(new FileWriter(
-					Config.getCurrentTransducerList()));
+		  File file = Config.getCurrentTransducerList();
+		  final String transducerFileName = file.getAbsolutePath();
+		  
+		  if (!transducerFileName.endsWith(".csc")) {
+		      file = new File(transducerFileName + ".csc");
+      }
+		  
+			final BufferedWriter fw = new BufferedWriter(new FileWriter(file));
 			for (int i = 0; i < table.getModel().getRowCount(); i++) {
 				final TransducerListTableModel model = (TransducerListTableModel) table.getModel();
 				final String fileName = (String) table.getValueAt(i, model.getNameIndex());

--- a/unitex/src/fr/umlv/unitex/graphrendering/GraphicalZone.java
+++ b/unitex/src/fr/umlv/unitex/graphrendering/GraphicalZone.java
@@ -1043,6 +1043,7 @@ public class GraphicalZone extends GenericGraphicalZone implements Printable {
 					box2, edit);
 			graphBoxes.add(outputBox);
 		}
+		unSelectAllBoxes();
 		postEdit(edit);
 		fireGraphChanged(true);
 	}

--- a/unitex/src/fr/umlv/unitex/graphrendering/GraphicalZone.java
+++ b/unitex/src/fr/umlv/unitex/graphrendering/GraphicalZone.java
@@ -308,7 +308,7 @@ public class GraphicalZone extends GenericGraphicalZone implements Printable {
                     public void actionPerformed(ActionEvent e) {
                         surroundWithBoxes(
                             (ArrayList<GenericGraphBox>) selectedBoxes.clone(),
-                            "$G/{", null);
+                            "$G/{", "<E>/}");
                     }
                 };
                 addGenericGraphIndicator.setEnabled(false);


### PR DESCRIPTION
This PR resolve 4 minor problems ;

- When clicking on the "$G" button in the graph edition frame, it now adds the closing curly bracket.
- For all the buttons that surround selected boxes (morphological, contexts etc), the previously selected boxes are unselected.
- The .csc extension is now automatically added when saving a CasSys cascade.
- You can chose between the three type of file when saving a new file creating from the "edition menu", and it automatically adds the correct extension.