### PR TITLE
[minor fix] Disable loop check when exploring graphs

### DIFF
--- a/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphFrame.java
@@ -1478,6 +1478,7 @@ public class GraphFrame extends KeyedInternalFrame<File> {
                     getGraph()) + "autolst.txt");
         pathCmd = pathCmd
                     .noLimit()
+                    .noLoopCheck()
                     .separateOutputs(true)
 				    .listsOfSubgraph(fst2);
         final Grf2Fst2Command grfCommand = new Grf2Fst2Command()

--- a/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
+++ b/unitex/src/fr/umlv/unitex/frames/GraphPathFrame.java
@@ -168,6 +168,7 @@ public class GraphPathFrame extends JInternalFrame {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
 				Fst2ListCommand cmd = new Fst2ListCommand();
+				cmd = cmd.noLoopCheck();
 				final Grf2Fst2Command grfCmd = new Grf2Fst2Command();
 				File fst2;
 				File list; /* output file name */

--- a/unitex/src/fr/umlv/unitex/process/commands/Fst2ListCommand.java
+++ b/unitex/src/fr/umlv/unitex/process/commands/Fst2ListCommand.java
@@ -45,6 +45,11 @@ public class Fst2ListCommand extends CommandBuilder {
 	public Fst2ListCommand noLimit() {
 		return this;
 	}
+	
+	public Fst2ListCommand noLoopCheck() {
+		element("-d");
+		return this;
+	}
 
 	public Fst2ListCommand mode(String s) { // multi or single
 		element("-t");


### PR DESCRIPTION
## Description
Add `-d` option to `Fst2List` command builder to disable loop check before exploration.

## Motivation and Context
When exploring graphs using `explore graph paths` for example, `Fst2List` performs an initial exploration to detect loops by default.
This behaviour poses problem when exploring graphs containing millions of paths, as even if you requested for the 2 first paths to be displayed, there will be a whole graph exploration before that.

## How Has This Been Tested?
This has been tested using DnumBillion.grf.

<!-- If this project features any kind of testing (unit, integration, regression), uncomment and complete the following checklist -->
<!-- - [ ] I have added tests to cover my changes  -->
<!-- - [ ] All new and existing tests passed  -->


## Type of files
<!-- What type of files does your pull request modify? Put an `x` in the box (only the mainly type) that apply: -->
- [ ] `bin`: Binary files
- [ ] `ci`: Continuous integration files
- [ ] `doc`: Documentation files
- [x] Plain-text source code files

## Level of change
<!-- What level of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `break`: Breaking change
- [ ] `exp`: Experimental change
- [ ] `tmp`: Temporal change
- [ ] `major`: Major change
- [ ] `minor`: Minor change
- [ ] `sec`: Vulnerability-related change
- [x] None of the above (normal change)

## Type of change
<!-- What type of change does your code introduce? Put an `x` in the box (only one) that apply: -->
- [ ] `deprecat`: Deprecation of a once-stable feature
- [x] `enhance`: Enhancement in existing functionality
- [ ] `fix`: Bug fix
- [ ] `feature`: New feature
- [ ] `hotfix`: Hotfix for bugs
- [ ] `refactor`: Improve coding style, comments
- [ ] `remove`: Remove a feature

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code compiles
- [x] My code follows the code style of this project
- [x] My code includes javadoc/doxygen where appropriate
- [x] My code is well factored, so that there is not repetitive code in the wild
- [x] My code does not require a change in the documentation, if so I already opened an issue to list the changes
- [x] I have read the **CONTRIBUTING** document
- [x] I have read the **Commit Message Guidelines**
- [x] I understand that all commits on my pull request will be squashed to a single good one
<!-- Check if all the points above have an `x`, if so you can submit your PR for review -->
